### PR TITLE
Fix tensor allocation overflow guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "bolt-cpu",
  "bytemuck",
  "thiserror",
+ "tinyvec",
 ]
 
 [[package]]
@@ -81,6 +82,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/bolt-core/Cargo.toml
+++ b/crates/bolt-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 thiserror.workspace = true
 bytemuck.workspace = true
+tinyvec = "1.10.0"
 
 [dev-dependencies]
 bolt-cpu = { path = "../bolt-cpu" }

--- a/crates/bolt-core/src/error.rs
+++ b/crates/bolt-core/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     #[error("size mismatch: expected {expected}, got {actual}")]
     SizeMismatch { expected: usize, actual: usize },
 
+    #[error("tensor too large: limit {limit} elements, requested {requested}")]
+    TensorTooLarge { limit: usize, requested: usize },
+
     #[error("op {op:?} is missing kernel for {device:?}/{dtype:?}")]
     KernelNotFound {
         op: OpKind,

--- a/crates/bolt-core/src/layout.rs
+++ b/crates/bolt-core/src/layout.rs
@@ -1,8 +1,9 @@
 use crate::{
     dtype::DType,
     error::{Error, Result},
-    shape::ConcreteShape,
+    shape::{ConcreteShape, MAX_RANK},
 };
+use tinyvec::ArrayVec;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LayoutKind {
@@ -13,7 +14,7 @@ pub enum LayoutKind {
 #[derive(Clone, Debug)]
 pub struct Layout {
     shape: ConcreteShape,
-    strides: Vec<isize>,
+    strides: ArrayVec<[isize; MAX_RANK]>,
     offset_bytes: usize,
     kind: LayoutKind,
 }
@@ -31,13 +32,17 @@ impl Layout {
 
     pub fn with_strides(
         shape: ConcreteShape,
-        strides: Vec<isize>,
+        strides: &[isize],
         offset_bytes: usize,
     ) -> Result<Self> {
         if shape.rank() != strides.len() {
             return Err(Error::invalid_shape("strides rank must match shape rank"));
         }
-        Ok(Self::new_unchecked(shape, strides, offset_bytes))
+        let mut stride_store = ArrayVec::<[isize; MAX_RANK]>::new();
+        for &stride in strides {
+            stride_store.push(stride);
+        }
+        Ok(Self::new_unchecked(shape, stride_store, offset_bytes))
     }
 
     pub fn shape(&self) -> &[usize] {
@@ -49,7 +54,7 @@ impl Layout {
     }
 
     pub fn strides(&self) -> &[isize] {
-        &self.strides
+        self.strides.as_slice()
     }
 
     pub fn offset_bytes(&self) -> usize {
@@ -94,7 +99,7 @@ impl Layout {
         let new_len = (end - start).div_ceil(step);
         let mut new_shape = self.shape().to_vec();
         new_shape[axis] = new_len;
-        let mut new_strides = self.strides().to_vec();
+        let mut new_strides = self.strides;
         new_strides[axis] *= step as isize;
         let stride = self.strides()[axis];
         let elem_offset = stride * start as isize;
@@ -104,7 +109,7 @@ impl Layout {
             .checked_add(byte_offset_delta as usize)
             .ok_or_else(|| Error::invalid_shape("slice offset overflow"))?;
         let shape = ConcreteShape::from_slice(&new_shape)?;
-        Layout::with_strides(shape, new_strides, offset_bytes)
+        Layout::with_strides(shape, new_strides.as_slice(), offset_bytes)
     }
 
     pub fn permute(&self, axes: &[usize]) -> Result<Self> {
@@ -125,13 +130,13 @@ impl Layout {
             seen[axis] = true;
         }
         let mut new_shape = Vec::with_capacity(axes.len());
-        let mut new_strides = Vec::with_capacity(axes.len());
+        let mut new_strides = ArrayVec::<[isize; MAX_RANK]>::new();
         for &axis in axes {
             new_shape.push(self.shape()[axis]);
             new_strides.push(self.strides()[axis]);
         }
         let shape = ConcreteShape::from_slice(&new_shape)?;
-        Layout::with_strides(shape, new_strides, self.offset_bytes)
+        Layout::with_strides(shape, new_strides.as_slice(), self.offset_bytes)
     }
 
     pub fn transpose(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
@@ -162,8 +167,12 @@ impl Layout {
         (self.offset_bytes / dtype.size_in_bytes()) as isize
     }
 
-    fn new_unchecked(shape: ConcreteShape, strides: Vec<isize>, offset_bytes: usize) -> Self {
-        let kind = compute_kind(shape.as_slice(), &strides);
+    fn new_unchecked(
+        shape: ConcreteShape,
+        strides: ArrayVec<[isize; MAX_RANK]>,
+        offset_bytes: usize,
+    ) -> Self {
+        let kind = compute_kind(shape.as_slice(), strides.as_slice());
         Self {
             shape,
             strides,

--- a/crates/bolt-core/src/shape.rs
+++ b/crates/bolt-core/src/shape.rs
@@ -1,21 +1,24 @@
 use crate::error::{Error, Result};
+use tinyvec::ArrayVec;
+
+pub const MAX_RANK: usize = 12;
+pub const MAX_ELEMENTS: usize = isize::MAX as usize;
 
 /// Runtime-validated shape metadata (rank >= 1, every dimension > 0).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConcreteShape {
-    dims: Vec<usize>,
+    dims: ArrayVec<[usize; MAX_RANK]>,
 }
 
 impl ConcreteShape {
     pub fn from_slice(dims: &[usize]) -> Result<Self> {
-        Self::validate_dims(dims)?;
         Ok(Self {
-            dims: dims.to_vec(),
+            dims: Self::collect_dims(dims)?,
         })
     }
 
     pub fn as_slice(&self) -> &[usize] {
-        &self.dims
+        self.dims.as_slice()
     }
 
     pub fn rank(&self) -> usize {
@@ -23,31 +26,64 @@ impl ConcreteShape {
     }
 
     pub fn num_elements(&self) -> usize {
-        self.dims.iter().product()
+        let mut num = 1usize;
+        for &dim in self.dims.iter() {
+            num = num
+                .checked_mul(dim)
+                .expect("shape invariant violated: num_elements overflow");
+        }
+        num
     }
 
-    pub fn contiguous_strides(&self) -> Vec<isize> {
-        let mut strides = vec![0isize; self.rank()];
+    pub fn contiguous_strides(&self) -> ArrayVec<[isize; MAX_RANK]> {
+        let rank = self.rank();
+        let mut strides = ArrayVec::<[isize; MAX_RANK]>::new();
+        for _ in 0..rank {
+            strides.push(0);
+        }
         let mut stride = 1isize;
-        for (i, dim) in self.dims.iter().enumerate().rev() {
+        for i in (0..rank).rev() {
+            let dim = self.dims[i];
             strides[i] = stride;
-            stride *= *dim as isize;
+            stride *= dim as isize;
         }
         strides
     }
 
-    fn validate_dims(dims: &[usize]) -> Result<()> {
+    fn collect_dims(dims: &[usize]) -> Result<ArrayVec<[usize; MAX_RANK]>> {
         if dims.is_empty() {
             return Err(Error::invalid_shape(
                 "shape must have at least one dimension",
             ));
         }
-        if dims.contains(&0) {
-            return Err(Error::invalid_shape(
-                "zero-sized dimensions are not supported",
-            ));
+        if dims.len() > MAX_RANK {
+            return Err(Error::invalid_shape(format!(
+                "tensor rank must be <= {MAX_RANK}"
+            )));
         }
-        Ok(())
+        let mut collected = ArrayVec::<[usize; MAX_RANK]>::new();
+        let mut num_elements = 1u128;
+        for &dim in dims {
+            if dim == 0 {
+                return Err(Error::invalid_shape(
+                    "zero-sized dimensions are not supported",
+                ));
+            }
+            num_elements = num_elements
+                .checked_mul(dim as u128)
+                .ok_or(Error::TensorTooLarge {
+                    limit: MAX_ELEMENTS,
+                    requested: usize::MAX,
+                })?;
+            if num_elements > MAX_ELEMENTS as u128 {
+                return Err(Error::TensorTooLarge {
+                    limit: MAX_ELEMENTS,
+                    requested: num_elements.try_into().unwrap_or(usize::MAX),
+                });
+            }
+            collected.push(dim);
+        }
+        Ok(collected)
     }
 }
 
@@ -61,8 +97,7 @@ impl TryFrom<Vec<usize>> for ConcreteShape {
     type Error = Error;
 
     fn try_from(dims: Vec<usize>) -> Result<Self> {
-        ConcreteShape::validate_dims(&dims)?;
-        Ok(Self { dims })
+        ConcreteShape::from_slice(&dims)
     }
 }
 

--- a/crates/bolt-core/src/tensor.rs
+++ b/crates/bolt-core/src/tensor.rs
@@ -285,7 +285,14 @@ impl Tensor {
         shape: ConcreteShape,
         dtype: DType,
     ) -> Result<Self> {
-        let len_bytes = shape.num_elements() * dtype.size_in_bytes();
+        let numel = shape.num_elements();
+        let dtype_size = dtype.size_in_bytes();
+        debug_assert!(dtype_size > 0, "dtype {dtype:?} reported zero size");
+        let elem_limit = usize::MAX / dtype_size;
+        let len_bytes = numel.checked_mul(dtype_size).ok_or(Error::TensorTooLarge {
+            limit: elem_limit,
+            requested: numel,
+        })?;
         let storage = Arc::new(TensorStorage::new(
             runtime.clone(),
             device_kind,

--- a/crates/bolt-core/tests/tensor_allocation_tests.rs
+++ b/crates/bolt-core/tests/tensor_allocation_tests.rs
@@ -1,0 +1,60 @@
+use bolt_core::{
+    device::DeviceKind,
+    dtype::DType,
+    error::{Error, Result},
+    shape::{ConcreteShape, MAX_ELEMENTS, MAX_RANK},
+};
+
+mod support;
+
+use support::test_runtime;
+
+#[test]
+fn rejects_rank_above_limit() {
+    let dims = vec![1usize; MAX_RANK + 1];
+    let err = ConcreteShape::from_slice(&dims).expect_err("rank > MAX_RANK must error");
+    assert!(matches!(err, Error::InvalidShape { .. }));
+}
+
+#[test]
+fn accepts_shape_at_element_limit() -> Result<()> {
+    let dims = [MAX_ELEMENTS];
+    let shape = ConcreteShape::from_slice(&dims)?;
+    assert_eq!(shape.num_elements(), MAX_ELEMENTS);
+    Ok(())
+}
+
+#[test]
+fn rejects_shape_exceeding_element_limit() {
+    let too_large = MAX_ELEMENTS
+        .checked_add(1)
+        .expect("MAX_ELEMENTS + 1 must fit in usize");
+    let err = ConcreteShape::from_slice(&[too_large]).expect_err("shape should be rejected");
+    match err {
+        Error::TensorTooLarge { limit, requested } => {
+            assert_eq!(limit, MAX_ELEMENTS);
+            assert_eq!(requested, too_large);
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn runtime_allocation_rejects_dtype_byte_overflow() -> Result<()> {
+    let runtime = test_runtime();
+    let dtype = DType::F64;
+    let elem_limit = usize::MAX / dtype.size_in_bytes();
+    let err = match runtime.allocate_uninit(DeviceKind::Cpu, &[elem_limit.saturating_add(1)], dtype)
+    {
+        Ok(_) => panic!("allocation should fail before device call"),
+        Err(err) => err,
+    };
+    match err {
+        Error::TensorTooLarge { limit, requested } => {
+            assert_eq!(limit, elem_limit);
+            assert_eq!(requested, elem_limit.saturating_add(1));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes https://github.com/ajkdrag/bolt-rs/issues/4

## What

- Added `tinyvec` and refactored `ConcreteShape`/`Layout` storage to inline `ArrayVec` with rank/element caps.
- Introduced `Error::TensorTooLarge` and guarded tensor allocation byte math with `checked_mul`.
- Added regression tests for rank overflow, element overflow, and dtype byte overflow scenarios.

## Why

Unchecked `usize` multiplication allowed silently allocating too-small buffers when `shape.num_elements()` overflowed or when multiplying by `dtype.size_in_bytes()` exceeded `usize::MAX`. Because shapes/strides were stored in unbounded `Vec`s, the runtime couldn’t prevent users from constructing ranks or element counts that the stride math can’t represent. These changes add explicit guardrails, cap ranks at 12, and ensure both shape validation and allocation raise `Error::TensorTooLarge` instead of corrupting memory. Inline storage also keeps typical tensor ranks fast without heap churn.

## How

- Swapped `ConcreteShape` dims/`Layout` strides to `ArrayVec` (`tinyvec`), enforced `MAX_RANK = 12`, and tracked cumulative elements with checked 128-bit arithmetic.
- Added `Error::TensorTooLarge` and re-used it for both shape construction overflow and dtype byte multiplication overflow inside `Tensor::allocate_with_shape`.
- Added `tensor_allocation_tests.rs` to assert rank cap, max-elements acceptance, overflow rejection, and runtime allocation failure when bytes overflow.

## Test Steps

What tests/scenarios have you covered?

- Rank and element limit validation for shapes and runtime allocation.
- Existing layout/runtime/tensor tests via `cargo test --all`.

What are all the steps to testing your code changes?

- [x] Run the following test(s) `cargo test --all`
- [x] You should expect all unit/integration tests to pass, including the new `tensor_allocation_tests`

## Checklist

- [x] Code compiles without errors
- [x] Wrote tests relevant to the PR
- [x] All tests pass
- [x] Ran the linter to ensure style guidelines were followed
- [x] Updated any relevant documentation

## Notes

N/A

What, if anything, hasn't been addressed in these code changes but should be in future changes?

- None at the moment; revisit rank cap if future workloads need >12 dims.
