### PR TITLE
Fix layout slice offset overflow

### DIFF
--- a/crates/bolt-core/src/layout.rs
+++ b/crates/bolt-core/src/layout.rs
@@ -102,14 +102,29 @@ impl Layout {
         let mut new_strides = self.strides;
         new_strides[axis] *= step as isize;
         let stride = self.strides()[axis];
-        let elem_offset = stride * start as isize;
-        let byte_offset_delta = elem_offset * dtype.size_in_bytes() as isize;
-        let offset_bytes = self
-            .offset_bytes()
-            .checked_add(byte_offset_delta as usize)
-            .ok_or_else(|| Error::invalid_shape("slice offset overflow"))?;
+        let offset_bytes =
+            Self::validate_slice_offset_bytes(stride, start, dtype, self.offset_bytes())?;
         let shape = ConcreteShape::from_slice(&new_shape)?;
         Layout::with_strides(shape, new_strides.as_slice(), offset_bytes)
+    }
+
+    fn validate_slice_offset_bytes(
+        stride: isize,
+        start: usize,
+        dtype: DType,
+        base_offset: usize,
+    ) -> Result<usize> {
+        let start_isize = isize::try_from(start)
+            .map_err(|_| Error::invalid_shape("slice start exceeds addressable range"))?;
+        let elem_offset = stride
+            .checked_mul(start_isize)
+            .ok_or_else(|| Error::invalid_shape("slice offset overflow (stride*start)"))?;
+        let byte_delta = elem_offset
+            .checked_mul(dtype.size_in_bytes() as isize)
+            .ok_or_else(|| Error::invalid_shape("slice offset overflow (bytes)"))?;
+        base_offset
+            .checked_add_signed(byte_delta)
+            .ok_or_else(|| Error::invalid_shape("slice offset overflow (base+delta)"))
     }
 
     pub fn permute(&self, axes: &[usize]) -> Result<Self> {

--- a/crates/bolt-core/tests/layout_tests.rs
+++ b/crates/bolt-core/tests/layout_tests.rs
@@ -11,6 +11,80 @@ fn layout_slice_updates_shape_and_offset() -> Result<()> {
 }
 
 #[test]
+fn layout_slice_overflow_positive_stride_still_ok() -> Result<()> {
+    let huge_stride = isize::MAX / 4;
+    let start = (isize::MAX / 2) as usize;
+    let shape = ConcreteShape::from_slice(&[start + 1, 1])?;
+    let layout = Layout::with_strides(shape, &[huge_stride, 1], 0)?;
+
+    let result = layout.slice(0, start, start + 1, 1, DType::F64);
+    assert!(result.is_err(), "slice unexpectedly succeeded despite overflowing stride math");
+    Ok(())
+}
+
+#[test]
+fn layout_slice_reports_stride_mul_overflow_error() -> Result<()> {
+    let (layout, start) = huge_stride_layout(isize::MAX / 4)?;
+    let err = layout
+        .slice(0, start, start + 1, 1, DType::F64)
+        .expect_err("expected stride/start overflow");
+    assert!(matches!(
+        err,
+        bolt_core::error::Error::InvalidShape { ref message }
+            if message == "slice offset overflow (stride*start)"
+    ));
+    Ok(())
+}
+
+#[test]
+fn layout_slice_reports_byte_mul_overflow_error() -> Result<()> {
+    let stride = (isize::MAX / 8) - 1;
+    let start = 8usize;
+    let shape = ConcreteShape::from_slice(&[start + 1, 1])?;
+    let layout = Layout::with_strides(shape, &[stride, 1], 0)?;
+    let err = layout
+        .slice(0, start, start + 1, 1, DType::F64)
+        .expect_err("expected byte overflow");
+    assert!(matches!(
+        err,
+        bolt_core::error::Error::InvalidShape { ref message }
+            if message == "slice offset overflow (bytes)"
+    ));
+    Ok(())
+}
+
+#[test]
+fn layout_slice_reports_base_plus_delta_overflow_error() -> Result<()> {
+    let dtype = DType::I32;
+    let shape = ConcreteShape::from_slice(&[4])?;
+    let layout = Layout::with_strides(shape, &[1], usize::MAX - 2)?;
+    let err = layout
+        .slice(0, 1, 2, 1, dtype)
+        .expect_err("expected base+delta overflow");
+    assert!(matches!(
+        err,
+        bolt_core::error::Error::InvalidShape { ref message }
+            if message == "slice offset overflow (base+delta)"
+    ));
+    Ok(())
+}
+
+#[test]
+fn layout_slice_supports_negative_stride_offsets() -> Result<()> {
+    let dtype = DType::F32;
+    let shape = ConcreteShape::from_slice(&[8])?;
+    let base_offset = (shape.as_slice()[0] - 1) * dtype.size_in_bytes();
+    let layout = Layout::with_strides(shape, &[-1], base_offset)?;
+    let sliced = layout.slice(0, 2, 4, 1, dtype)?;
+    assert_eq!(sliced.strides()[0], -1);
+    assert_eq!(
+        sliced.offset_bytes(),
+        base_offset - 2 * dtype.size_in_bytes()
+    );
+    Ok(())
+}
+
+#[test]
 fn layout_permute_swaps_axes() -> Result<()> {
     let base = Layout::contiguous(ConcreteShape::from_slice(&[2, 3, 4])?);
     let permuted = base.permute(&[2, 0, 1])?;
@@ -39,4 +113,11 @@ fn reshape_rejects_invalid_element_counts() -> Result<()> {
         Err(bolt_core::error::Error::SizeMismatch { .. })
     ));
     Ok(())
+}
+
+fn huge_stride_layout(stride: isize) -> Result<(Layout, usize)> {
+    let start = (isize::MAX / 2) as usize;
+    let shape = ConcreteShape::from_slice(&[start + 1, 1])?;
+    let layout = Layout::with_strides(shape, &[stride, 1], 0)?;
+    Ok((layout, start))
 }


### PR DESCRIPTION
Closes https://github.com/ajkdrag/bolt-rs/issues/6

## What

- Added validate_slice_offset_bytes helper in Layout::slice to guard stride/start/dtype arithmetic
- Updated layout slicing tests with overflow repro and explicit error cases plus negative stride coverage
- Wired slice() to the new helper so unchecked math paths are eliminated

## Why

Layout::slice previously multiplied stride/start and byte deltas using unchecked isize arithmetic, so large or negative strides could wrap before the final checked_add saw the overflow. That lets slices succeed even though the byte offset now points outside the buffer, violating the eager runtime contract. The helper ensures every intermediate step fails loudly with descriptive InvalidShape messages (similar to PR #5), and the targeted tests both reproduce the original issue and lock in the new guardrails, covering negative strides for the upcoming reverse-slice ergonomics.

## How

- Introduced validate_slice_offset_bytes with checked_mul/checked_add_signed for stride*start, byte delta, and base+delta calculations, plus start casting guard
- Replaced manual arithmetic in Layout::slice with the helper while leaving stride/shape logic intact
- Added tests that simulate the issue (large positive stride/start) and verify each error path + a negative-stride success case

## Test Steps

- Overflow reproduction succeeds: layout_slice_overflow_positive_stride_still_ok
- Stride overflow error: layout_slice_reports_stride_mul_overflow_error
- Byte overflow error: layout_slice_reports_byte_mul_overflow_error
- Base+delta overflow error: layout_slice_reports_base_plus_delta_overflow_error
- Negative stride behavior: layout_slice_supports_negative_stride_offsets
- Aggregate slice tests: cargo test layout_slice

What are all the steps to testing your code changes?

- [x] Run cargo test layout_slice_overflow_positive_stride_still_ok
- [x] Run cargo test layout_slice_reports_stride_mul_overflow_error
- [x] Run cargo test layout_slice_reports_byte_mul_overflow_error
- [x] Run cargo test layout_slice_reports_base_plus_delta_overflow_error
- [x] Run cargo test layout_slice_supports_negative_stride_offsets
- [x] Run cargo test layout_slice
- [x] Expect each command to pass without failures

## Checklist

- [x] Code compiles without errors
- [x] Wrote tests relevant to the PR
- [x] All tests pass
- [ ] Ran the linter to ensure style guidelines were followed
- [x] Updated any relevant documentation

## Notes

- Guards keep code localized; no allocator/backends touched
- Future layout math (e.g., reverse slicing API) can reuse the helper to stay consistent
- No lint target configured; left unchecked for now

What, if anything, hasn’t been addressed?

- No benchmarks to measure branch cost; correctness prioritized per spec
- Could consider integrating helper into other layout paths if they evolve
