### PR TITLE
[feature] Add Tensor::broadcast_to method

### DIFF
--- a/crates/bolt-autodiff/src/ops/mod.rs
+++ b/crates/bolt-autodiff/src/ops/mod.rs
@@ -126,35 +126,3 @@ where
     Ok(result)
 }
 
-pub(crate) fn broadcast_to<B, D>(
-    tensor: &Tensor<B, D>,
-    target_shape: &[usize],
-) -> Result<Tensor<B, D>>
-where
-    B: Backend<D> + CopyOp<D>,
-    D: Float,
-{
-    if tensor.shape() == target_shape {
-        return Ok(tensor.clone());
-    }
-
-    let src_shape = tensor.shape();
-    let src_rank = src_shape.len();
-    let target_rank = target_shape.len();
-
-    let mut current = tensor.clone();
-
-    if src_rank < target_rank {
-        let mut new_shape = vec![1; target_rank - src_rank];
-        new_shape.extend_from_slice(src_shape);
-        current = current.reshape(&new_shape)?;
-    }
-
-    let layout = current
-        .layout()
-        .broadcast_to(&bolt_core::shape::ConcreteShape::from_slice(target_shape)?)?;
-
-    let result = Tensor::from_parts(current.backend(), current.storage().clone(), layout);
-
-    Ok(result.contiguous()?)
-}

--- a/crates/bolt-autodiff/src/ops/reduce.rs
+++ b/crates/bolt-autodiff/src/ops/reduce.rs
@@ -5,7 +5,7 @@ use tinyvec::ArrayVec;
 
 use crate::backward::{BackwardContext, BackwardOp, MAX_INPUTS};
 use crate::error::Result;
-use crate::ops::{broadcast_to, sum_axis};
+use crate::ops::sum_axis;
 use crate::{Float, GradTensor};
 
 pub struct SumBackward {
@@ -28,7 +28,7 @@ where
         grad_output: &Tensor<B, D>,
         _ctx: &BackwardContext<B, D>,
     ) -> Result<ArrayVec<[Option<Tensor<B, D>>; MAX_INPUTS]>> {
-        let grad_input = broadcast_to(grad_output, &self.input_shape)?;
+        let grad_input = grad_output.broadcast_to(&self.input_shape)?;
         let mut result = ArrayVec::new();
         result.push(Some(grad_input));
         Ok(result)
@@ -63,7 +63,7 @@ where
         let scale = D::one() / D::from_usize(self.count);
         let scaled =
             Tensor::full(&grad_output.backend(), grad_output.shape(), scale)?.mul(grad_output)?;
-        let grad_input = broadcast_to(&scaled, &self.input_shape)?;
+        let grad_input = scaled.broadcast_to(&self.input_shape)?;
         let mut result = ArrayVec::new();
         result.push(Some(grad_input));
         Ok(result)

--- a/crates/bolt-core/src/tensor.rs
+++ b/crates/bolt-core/src/tensor.rs
@@ -203,6 +203,56 @@ where
         Ok(self.with_layout(layout))
     }
 
+    /// Returns a broadcast view sharing the same storage as `self`.
+    ///
+    /// Broadcasting follows NumPy semantics: dimensions must be compatible (size 1 or matching).
+    /// If the source tensor has lower rank than the target shape, it is reshaped by prepending
+    /// dimensions of size 1.
+    ///
+    /// The result is a view with zero-copy: broadcasted dimensions have stride 0.
+    /// Call `.contiguous()` explicitly if you need a contiguous copy for performance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use bolt_core::{Tensor, Backend, Result};
+    /// # use bolt_cpu::CpuBackend;
+    /// # use std::sync::Arc;
+    /// # fn example<B: Backend<f32>>(backend: &Arc<B>) -> Result<()> {
+    /// let tensor = Tensor::from_slice(backend, &[1.0, 2.0], &[2])?;
+    /// let broadcasted = tensor.broadcast_to(&[3, 2])?;
+    /// assert_eq!(broadcasted.shape(), &[3, 2]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::ShapeMismatch` if the shapes are incompatible for broadcasting.
+    pub fn broadcast_to(&self, shape: &[usize]) -> Result<Self> {
+        let target_shape = ConcreteShape::from_slice(shape)?;
+        let src_shape = self.layout.concrete_shape().as_slice();
+        let src_rank = src_shape.len();
+        let target_rank = target_shape.as_slice().len();
+
+        let mut current = self.clone();
+
+        if src_rank < target_rank {
+            let mut reshaped = vec![1; target_rank - src_rank];
+            reshaped.extend_from_slice(src_shape);
+            current = current.reshape(&reshaped)?;
+        }
+
+        let layout = current.layout().broadcast_to(&target_shape)?;
+        current.validate_layout_for_storage(&current.storage, &layout)?;
+
+        Ok(Self::from_parts(
+            current.backend.clone(),
+            current.storage.clone(),
+            layout,
+        ))
+    }
+
     pub fn transpose(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
         let layout = self.layout.transpose(axis_a, axis_b)?;
         self.validate_layout_for_storage(&self.storage, &layout)?;

--- a/crates/bolt-cpu/tests/broadcast_tests.rs
+++ b/crates/bolt-cpu/tests/broadcast_tests.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use bolt_core::error::Error;
+use bolt_core::Result;
+use bolt_core::tensor::Tensor;
+use bolt_cpu::CpuBackend;
+
+#[test]
+fn broadcast_scalar_to_vector() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+
+    let scalar = Tensor::<CpuBackend, f32>::from_slice(&backend, &[5.0], &[1])?;
+    let broadcasted = scalar.broadcast_to(&[3])?;
+
+    assert_eq!(broadcasted.shape(), &[3]);
+    assert_eq!(broadcasted.to_vec()?, vec![5.0, 5.0, 5.0]);
+
+    Ok(())
+}
+
+#[test]
+fn broadcast_rank_increase_updates_strides() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+
+    let vector = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 2.0], &[2])?;
+    let broadcasted = vector.broadcast_to(&[3, 2])?;
+
+    assert_eq!(broadcasted.shape(), &[3, 2]);
+    let strides = broadcasted.strides();
+    assert_eq!(strides[0], 0);
+    assert_ne!(strides[1], 0);
+
+    let expected = vec![1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
+    assert_eq!(broadcasted.to_vec()?, expected);
+
+    Ok(())
+}
+
+#[test]
+fn broadcast_incompatible_shape_errors() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 2.0, 3.0], &[3])?;
+    let err = tensor.broadcast_to(&[2]);
+
+    assert!(matches!(err, Err(Error::ShapeMismatch { .. })));
+    Ok(())
+}
+
+#[test]
+fn broadcast_then_elementwise_ops() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+
+    let scalar = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0], &[1])?;
+    let values = Tensor::<CpuBackend, f32>::from_slice(&backend, &[2.0, 3.0, 4.0], &[3])?;
+
+    let broadcasted = scalar.broadcast_to(&[3])?;
+    let sum = broadcasted.add(&values)?.to_vec()?;
+    let prod = broadcasted.mul(&values)?.to_vec()?;
+
+    assert_eq!(sum, vec![3.0, 4.0, 5.0]);
+    assert_eq!(prod, vec![2.0, 3.0, 4.0]);
+
+    Ok(())
+}
+
+#[test]
+fn broadcast_then_matmul() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+
+    let row = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 0.0], &[1, 2])?;
+    let weights = Tensor::<CpuBackend, f32>::from_slice(&backend, &[2.0, 3.0], &[2, 1])?;
+
+    let broadcasted = row.broadcast_to(&[3, 2])?;
+    let product = broadcasted.matmul(&weights)?.to_vec()?;
+
+    assert_eq!(product, vec![2.0, 2.0, 2.0]);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #47

## What
- Added public `Tensor::broadcast_to(&self, shape: &[usize]) -> Result<Self>` method
- Handles rank mismatches by prepending dimensions of size 1 (NumPy semantics)
- Returns zero-copy views with adjusted strides for broadcasted dimensions
- Added comprehensive tests covering success/error cases and backend integration
- Refactored autodiff backward passes to use public API instead of internal helper

## Why
Users currently cannot broadcast tensors ergonomically. Broadcasting is a fundamental tensor operation in numerical computing (matching NumPy, PyTorch semantics), yet there was no public API. This enables use cases like implicit broadcasting in compound operations and explicit shape manipulation for clarity.

## How
- Implemented `broadcast_to` method in `crates/bolt-core/src/tensor.rs` that delegates to existing `Layout::broadcast_to` logic
- Added rank adjustment by reshaping with prepended 1s when source rank < target rank
- Created `crates/bolt-cpu/tests/broadcast_tests.rs` with 5 test scenarios covering all edge cases
- Removed internal `broadcast_to` function from autodiff and updated call sites to use public API
- All changes reuse existing patterns and maintain zero-copy performance

## Test Steps
- [x] Run `cargo test -p bolt-core` (passes)
- [x] Run `cargo test -p bolt-cpu` (passes, including 5 new broadcast tests)  
- [x] Run `cargo test -p bolt-autodiff` (passes, confirms backward passes work)
- [x] Run `cargo test --all` (passes all 78 tests)

## Checklist
- [x] Code compiles without errors
- [x] Wrote tests relevant to the PR (5 comprehensive broadcast tests)
- [x] All tests pass
- [x] Ran the linter (cargo check passes)
- [x] Updated any relevant documentation (method has doc comments)
- [x] Follows existing tensor API patterns (reshape, permute, transpose)

## Notes
The method returns non-contiguous views with zero strides for broadcasted dimensions. Users should call `.contiguous()` explicitly if they need contiguous memory for certain operations. This design prioritizes performance over forcing contiguity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `broadcast_to()` method on Tensor for zero-copy broadcasting operations with NumPy-style shape compatibility.

* **Tests**
  * Added comprehensive test suite validating broadcasting behavior with scalar-to-vector, rank expansion, error handling, and combined tensor operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->