### PR TITLE
Add keepdims parameter to mean/sum and refactor MeanOp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ devlog/
 bun.lock
 node_modules/
 package.json
+.DS_Store
  
  
 

--- a/crates/bolt-autodiff/src/float.rs
+++ b/crates/bolt-autodiff/src/float.rs
@@ -1,6 +1,6 @@
-use bolt_core::dtype::NativeType;
+use bolt_core::dtype::FloatType;
 
-pub trait Float: NativeType + num_traits::Float + Default + Send + Sync {
+pub trait Float: FloatType + num_traits::Float + Default + Send + Sync {
     fn from_usize(n: usize) -> Self;
 }
 

--- a/crates/bolt-autodiff/src/ops/reduce.rs
+++ b/crates/bolt-autodiff/src/ops/reduce.rs
@@ -1,4 +1,4 @@
-use bolt_core::backend::{AddOp, CopyOp, FillOp, MulOp, SumOp};
+use bolt_core::backend::{AddOp, CopyOp, FillOp, MeanOp, MulOp, SumOp};
 use bolt_core::shape;
 use bolt_core::{Backend, Tensor};
 use tinyvec::ArrayVec;
@@ -102,24 +102,16 @@ where
     }
 }
 
-fn sum_impl<B, D>(tensor: &Tensor<B, D>, axes: Option<&[usize]>) -> Result<Tensor<B, D>>
-where
-    B: Backend<D> + SumOp<D>,
-    D: Float,
-{
-    Ok(tensor.sum(axes, false)?)
-}
-
 impl<'g, B, D> GradTensor<'g, B, D>
 where
     B: Backend<D> + AddOp<D> + FillOp<D> + SumOp<D> + CopyOp<D>,
     D: Float,
 {
-    pub fn sum(&self, axes: Option<&[usize]>) -> Result<GradTensor<'g, B, D>> {
+    pub fn sum(&self, axes: Option<&[usize]>, keepdims: bool) -> Result<GradTensor<'g, B, D>> {
         let self_tensor = self.tensor()?;
         let input_shape = self_tensor.shape().to_vec();
 
-        let result = sum_impl(&self_tensor, axes)?;
+        let result = self_tensor.sum(axes, keepdims)?;
 
         let requires_grad = self.requires_grad()? && self.graph().is_grad_enabled();
 
@@ -145,27 +137,24 @@ where
 
 impl<'g, B, D> GradTensor<'g, B, D>
 where
-    B: Backend<D> + AddOp<D> + FillOp<D> + MulOp<D> + SumOp<D> + CopyOp<D>,
+    B: Backend<D> + AddOp<D> + FillOp<D> + MulOp<D> + MeanOp<D> + CopyOp<D>,
     D: Float,
 {
-    pub fn mean(&self, axes: Option<&[usize]>) -> Result<GradTensor<'g, B, D>> {
+    pub fn mean(&self, axes: Option<&[usize]>, keepdims: bool) -> Result<GradTensor<'g, B, D>> {
         let self_tensor = self.tensor()?;
         let input_shape = self_tensor.shape().to_vec();
 
-        let axes_canonical = match axes {
-            None => None,
-            Some(axes) => Some(shape::canonical_axes(axes, input_shape.len())?),
-        };
-
-        let count = match &axes_canonical {
+        // Compute count for backward pass
+        let count = match axes {
             None => self_tensor.numel(),
-            Some(axes) => axes.iter().map(|&a| input_shape[a]).product(),
+            Some(ax) => {
+                let canonical = shape::canonical_axes(ax, input_shape.len())?;
+                canonical.iter().map(|&a| input_shape[a]).product()
+            }
         };
 
-        let sum_result = sum_impl(&self_tensor, axes_canonical.as_deref())?;
-        let scale = D::one() / D::from_usize(count);
-        let result =
-            Tensor::full(&sum_result.backend(), sum_result.shape(), scale)?.mul(&sum_result)?;
+        // Clean delegation to Tensor API
+        let result = self_tensor.mean(axes, keepdims)?;
 
         let requires_grad = self.requires_grad()? && self.graph().is_grad_enabled();
 
@@ -174,7 +163,7 @@ where
         }
 
         let saved_idx = self.graph().save_tensors_for_backward(vec![]);
-        let backward_op = MeanBackward::new(input_shape, axes_canonical.clone(), count);
+        let backward_op = MeanBackward::new(input_shape, axes.map(|a| a.to_vec()), count);
 
         let mut inputs = ArrayVec::new();
         inputs.push(self.handle());

--- a/crates/bolt-autodiff/tests/basic_ops.rs
+++ b/crates/bolt-autodiff/tests/basic_ops.rs
@@ -39,7 +39,7 @@ fn test_add_grad_simple() -> Result<()> {
     let a = graph.param(&a_data);
     let b = graph.param(&b_data);
     let c = a.add(&b)?;
-    let loss = c.sum(None)?;
+    let loss = c.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -63,7 +63,7 @@ fn test_mul_grad_simple() -> Result<()> {
     let a = graph.param(&a_data);
     let b = graph.param(&b_data);
     let c = a.mul(&b)?;
-    let loss = c.sum(None)?;
+    let loss = c.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -87,7 +87,7 @@ fn test_sub_grad_simple() -> Result<()> {
     let a = graph.param(&a_data);
     let b = graph.param(&b_data);
     let c = a.sub(&b)?;
-    let loss = c.sum(None)?;
+    let loss = c.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -109,7 +109,7 @@ fn test_chain_rule() -> Result<()> {
     let x = graph.param(&x_data);
 
     let y = x.mul(&x)?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -128,7 +128,7 @@ fn test_multiple_use_accumulation() -> Result<()> {
     let x = graph.param(&x_data);
 
     let y = x.add(&x)?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -146,7 +146,7 @@ fn test_mean_grad() -> Result<()> {
     let x_data = Tensor::from_slice(&backend, &[1.0_f32, 2.0, 3.0, 4.0], &[4])?;
     let x = graph.param(&x_data);
 
-    let loss = x.mean(None)?;
+    let loss = x.mean(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -168,7 +168,7 @@ fn test_no_grad_tensor() -> Result<()> {
     let y = graph.param(&y_data);
 
     let z = x.add(&y)?;
-    let loss = z.sum(None)?;
+    let loss = z.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -195,7 +195,7 @@ fn test_detach() -> Result<()> {
     let y = x.mul(&x)?;
     let y_detached = y.detach()?;
     let z = y_detached.add(&w)?;
-    let loss = z.sum(None)?;
+    let loss = z.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -214,7 +214,7 @@ fn test_reshape_backward() -> Result<()> {
     let x = graph.param(&x_data);
 
     let y = x.reshape(&[4])?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -233,7 +233,7 @@ fn test_transpose_backward() -> Result<()> {
     let x = graph.param(&x_data);
 
     let y = x.transpose(0, 1)?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -256,7 +256,7 @@ fn test_graph_clear_invalidates_handles() -> Result<()> {
 
     let y_data = Tensor::from_slice(&backend, &[2.0_f32], &[1])?;
     let y = graph.param(&y_data);
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -297,7 +297,7 @@ fn test_complex_expression() -> Result<()> {
 
     let a = x.mul(&y)?;
     let b = a.add(&x)?;
-    let loss = b.sum(None)?;
+    let loss = b.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -326,9 +326,9 @@ fn test_dynamic_control_flow_branch_true() -> Result<()> {
     let condition_value = x.tensor()?.item()?;
 
     let loss = if condition_value > 2.0 {
-        x.mul(&w1)?.sum(None)?
+        x.mul(&w1)?.sum(None, false)?
     } else {
-        x.mul(&w2)?.sum(None)?
+        x.mul(&w2)?.sum(None, false)?
     };
 
     let grads = graph.backward(&loss)?;
@@ -357,9 +357,9 @@ fn test_dynamic_control_flow_branch_false() -> Result<()> {
     let condition_value = x.tensor()?.item()?;
 
     let loss = if condition_value > 2.0 {
-        x.mul(&w1)?.sum(None)?
+        x.mul(&w1)?.sum(None, false)?
     } else {
-        x.mul(&w2)?.sum(None)?
+        x.mul(&w2)?.sum(None, false)?
     };
 
     let grads = graph.backward(&loss)?;
@@ -389,7 +389,7 @@ fn test_dynamic_loop_iterations() -> Result<()> {
     for _ in 1..iterations {
         result = result.mul(&w)?;
     }
-    let loss = result.sum(None)?;
+    let loss = result.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -411,7 +411,7 @@ fn test_sum_multi_axis_backward() -> Result<()> {
     )?;
     let x = graph.param(&x_data);
 
-    let y = x.sum(Some(&[0, 2]))?;
+    let y = x.sum(Some(&[0, 2]), false)?;
 
     let grads = graph.backward(&y)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;
@@ -434,7 +434,7 @@ fn test_mean_multi_axis_backward() -> Result<()> {
     )?;
     let x = graph.param(&x_data);
 
-    let y = x.mean(Some(&[0, 2]))?;
+    let y = x.mean(Some(&[0, 2]), false)?;
 
     let grads = graph.backward(&y)?;
     let dx = grads.wrt(&x).expect("gradient for x").to_vec()?;

--- a/crates/bolt-autodiff/tests/dtypes.rs
+++ b/crates/bolt-autodiff/tests/dtypes.rs
@@ -39,7 +39,7 @@ fn test_f32_autodiff_gradients() -> Result<()> {
 
     let a = graph.param(&a_data);
     let b = graph.param(&b_data);
-    let loss = a.add(&b)?.sum(None)?;
+    let loss = a.add(&b)?.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let expected = vec![1.0_f32; 3];
@@ -63,7 +63,7 @@ fn test_f64_autodiff_gradients() -> Result<()> {
 
     let a = graph.param(&a_data);
     let b = graph.param(&b_data);
-    let loss = a.add(&b)?.sum(None)?;
+    let loss = a.add(&b)?.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let expected = vec![1.0_f64; 3];

--- a/crates/bolt-autodiff/tests/fluent_api.rs
+++ b/crates/bolt-autodiff/tests/fluent_api.rs
@@ -43,7 +43,7 @@ fn test_fluent_api_param_input() -> Result<()> {
     assert!(!b.requires_grad()?);
 
     let c = a.add(&b)?;
-    let loss = c.sum(None)?;
+    let loss = c.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
 
@@ -67,7 +67,7 @@ fn test_tensor_like_mixing_gradtensor_and_tensor() -> Result<()> {
 
     // This should work: GradTensor.add(Tensor)
     let y = w.add(&x_data)?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dw = grads.wrt(&w).expect("gradient for w").to_vec()?;
@@ -87,7 +87,7 @@ fn test_matmul_tensor_like() -> Result<()> {
     let w = graph.param(&w_data);
 
     let y = w.matmul(&x_data)?;
-    let loss = y.sum(None)?;
+    let loss = y.sum(None, false)?;
 
     let grads = graph.backward(&loss)?;
     let dw = grads.wrt(&w).expect("gradient for w").to_vec()?;

--- a/crates/bolt-core/src/backend.rs
+++ b/crates/bolt-core/src/backend.rs
@@ -76,14 +76,14 @@ pub trait MatmulOp<D: NativeType>: Backend<D> {
     ) -> Result<TensorParts<Self::Storage>>;
 }
 
-pub trait MeanOp<D: NativeType>: Backend<D> {
-    type F32Storage: Clone + Send + Sync + 'static;
-
-    fn mean_f32(
+pub trait MeanOp<D: FloatType>: Backend<D> {
+    fn mean(
         &self,
-        storage: &<Self as Backend<D>>::Storage,
         layout: &Layout,
-    ) -> Result<TensorParts<Self::F32Storage>>;
+        storage: &Self::Storage,
+        axes: Option<&[usize]>,
+        keepdims: bool,
+    ) -> Result<TensorParts<Self::Storage>>;
 }
 
 pub trait NegOp<D: NativeType>: Backend<D> {

--- a/crates/bolt-core/src/tensor.rs
+++ b/crates/bolt-core/src/tensor.rs
@@ -7,7 +7,7 @@ use crate::{
         MatmulOp, MaxOp, MeanOp, MinOp, MulOp, NegOp, PowOp, ProdOp, ReluOp, SinOp, SqrtOp, SubOp,
         SumOp, TanhOp,
     },
-    dtype::{FloatType, NativeType, OneValue, ToF32},
+    dtype::{FloatType, NativeType, OneValue},
     error::{Error, Result},
     index::TensorIndex,
     layout::Layout,
@@ -293,32 +293,6 @@ where
         Ok(self.with_layout(layout))
     }
 
-    /// Returns a broadcast view sharing the same storage as `self`.
-    ///
-    /// Broadcasting follows NumPy semantics: dimensions must be compatible (size 1 or matching).
-    /// If the source tensor has lower rank than the target shape, it is reshaped by prepending
-    /// dimensions of size 1.
-    ///
-    /// The result is a view with zero-copy: broadcasted dimensions have stride 0.
-    /// Call `.contiguous()` explicitly if you need a contiguous copy for performance.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use bolt_core::{Tensor, Backend, Result};
-    /// # use bolt_cpu::CpuBackend;
-    /// # use std::sync::Arc;
-    /// # fn example<B: Backend<f32>>(backend: &Arc<B>) -> Result<()> {
-    /// let tensor = Tensor::from_slice(backend, &[1.0, 2.0], &[2])?;
-    /// let broadcasted = tensor.broadcast_to(&[3, 2])?;
-    /// assert_eq!(broadcasted.shape(), &[3, 2]);
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Errors
-    ///
-    /// Returns `Error::ShapeMismatch` if the shapes are incompatible for broadcasting.
     pub fn broadcast_to(&self, shape: &[usize]) -> Result<Self> {
         let target_shape = ConcreteShape::from_slice(shape)?;
         let src_shape = self.layout.concrete_shape().as_slice();
@@ -425,13 +399,15 @@ where
         ))
     }
 
-    pub fn mean_f32(&self) -> Result<Tensor<B, f32>>
+    pub fn mean(&self, axes: Option<&[usize]>, keepdims: bool) -> Result<Self>
     where
-        B: Backend<f32> + MeanOp<D, F32Storage = <B as Backend<f32>>::Storage>,
-        D: ToF32,
+        B: MeanOp<D>,
+        D: FloatType,
     {
-        let parts = MeanOp::<D>::mean_f32(self.backend.as_ref(), &self.storage, &self.layout)?;
-        Ok(Tensor::<B, f32>::from_parts(
+        let parts = self
+            .backend
+            .mean(&self.layout, &self.storage, axes, keepdims)?;
+        Ok(Self::from_parts(
             self.backend.clone(),
             parts.storage,
             parts.layout,
@@ -587,7 +563,9 @@ where
     where
         B: SumOp<D>,
     {
-        let parts = self.backend.sum(&self.layout, &self.storage, axes, keepdims)?;
+        let parts = self
+            .backend
+            .sum(&self.layout, &self.storage, axes, keepdims)?;
         Ok(Self::from_parts(
             self.backend.clone(),
             parts.storage,
@@ -599,7 +577,9 @@ where
     where
         B: ProdOp<D>,
     {
-        let parts = self.backend.prod(&self.layout, &self.storage, axes, keepdims)?;
+        let parts = self
+            .backend
+            .prod(&self.layout, &self.storage, axes, keepdims)?;
         Ok(Self::from_parts(
             self.backend.clone(),
             parts.storage,
@@ -611,7 +591,9 @@ where
     where
         B: MinOp<D>,
     {
-        let parts = self.backend.min(&self.layout, &self.storage, axes, keepdims)?;
+        let parts = self
+            .backend
+            .min(&self.layout, &self.storage, axes, keepdims)?;
         Ok(Self::from_parts(
             self.backend.clone(),
             parts.storage,
@@ -623,7 +605,9 @@ where
     where
         B: MaxOp<D>,
     {
-        let parts = self.backend.max(&self.layout, &self.storage, axes, keepdims)?;
+        let parts = self
+            .backend
+            .max(&self.layout, &self.storage, axes, keepdims)?;
         Ok(Self::from_parts(
             self.backend.clone(),
             parts.storage,

--- a/crates/bolt-cpu/src/backend/mod.rs
+++ b/crates/bolt-cpu/src/backend/mod.rs
@@ -232,15 +232,19 @@ impl<D> MeanOp<D> for CpuBackend
 where
     D: CpuScalar + MeanKernel,
 {
-    type F32Storage = CpuStorage<f32>;
-
-    fn mean_f32(
+    fn mean(
         &self,
-        storage: &<Self as Backend<D>>::Storage,
         layout: &Layout,
-    ) -> Result<TensorParts<Self::F32Storage>> {
-        let allocator = <Self as Backend<f32>>::allocator(self);
-        <D as MeanKernel>::mean_f32_kernel(TensorView::new(storage, layout), &allocator)
+        storage: &Self::Storage,
+        axes: Option<&[usize]>,
+        keepdims: bool,
+    ) -> Result<TensorParts<Self::Storage>> {
+        <D as MeanKernel>::mean_kernel(
+            TensorView::new(storage, layout),
+            axes,
+            keepdims,
+            &self.allocator(),
+        )
     }
 }
 

--- a/crates/bolt-cpu/src/backend/ops/mean.rs
+++ b/crates/bolt-cpu/src/backend/ops/mean.rs
@@ -1,59 +1,118 @@
 use bolt_core::{
     StorageAllocator, TensorParts,
-    dtype::{NativeType, ToF32},
+    dtype::FloatType,
     error::{Error, Result},
     layout::Layout,
-    shape::ConcreteShape,
+    shape::{ConcreteShape, canonical_axes},
 };
 
 use super::super::allocator::CpuAllocator;
 use super::super::storage::{CpuStorage, CpuTensorView};
+use super::reduction_helpers::{
+    compute_multi_index_from_linear, compute_output_linear_index, compute_reduction_shape,
+};
 
-pub trait MeanKernel: NativeType + ToF32 {
-    fn mean_f32_kernel(
-        input: CpuTensorView<'_, Self>,
-        alloc_f32: &CpuAllocator<f32>,
-    ) -> Result<TensorParts<CpuStorage<f32>>>;
+pub trait MeanKernel: FloatType {
+    fn mean_kernel(
+        _view: CpuTensorView<'_, Self>,
+        _axes: Option<&[usize]>,
+        _keepdims: bool,
+        _allocator: &CpuAllocator<Self>,
+    ) -> Result<TensorParts<CpuStorage<Self>>> {
+        Err(Error::OpError(format!(
+            "mean not implemented for {}",
+            Self::DTYPE
+        )))
+    }
 }
 
-fn reduce_to_mean_f32<D>(
+fn reduce_mean<D>(
     input: CpuTensorView<'_, D>,
-    alloc_f32: &CpuAllocator<f32>,
-) -> Result<TensorParts<CpuStorage<f32>>>
+    axes: Option<&[usize]>,
+    keepdims: bool,
+    allocator: &CpuAllocator<D>,
+) -> Result<TensorParts<CpuStorage<D>>>
 where
-    D: NativeType + ToF32 + Copy,
+    D: FloatType + num_traits::Float,
 {
-    let shape = input.layout.shape();
-    let numel: usize = shape.iter().product();
-    if numel == 0 {
+    let input_shape = input.layout.shape();
+    let output_shape = compute_reduction_shape(input_shape, axes, keepdims)?;
+
+    if let Some(ax) = axes {
+        canonical_axes(ax, input_shape.len())?;
+    }
+
+    // Compute count of elements being reduced
+    let count = if let Some(ax) = axes {
+        let canonical = canonical_axes(ax, input_shape.len())?;
+        canonical.iter().map(|&a| input_shape[a]).product::<usize>()
+    } else {
+        input_shape.iter().product::<usize>()
+    };
+
+    if count == 0 {
         return Err(Error::OpError("cannot compute mean of empty tensor".into()));
     }
 
-    let data = input.storage.as_uninit_slice();
-    let mut sum: f32 = 0.0;
+    let output_numel: usize = if output_shape.is_empty() {
+        1
+    } else {
+        output_shape.iter().product()
+    };
+
+    let mut out_storage = allocator.allocate(output_numel)?;
+    let out_data = out_storage.try_as_uninit_slice_mut()?;
+
+    for slot in out_data.iter_mut().take(output_numel) {
+        slot.write(D::default());
+    }
+
+    let input_data = input.storage.as_uninit_slice();
     let elem_size = D::DTYPE.size_in_bytes();
 
-    if input.layout.is_contiguous() && input.layout.offset_bytes() == 0 {
-        if data.len() < numel {
-            return Err(Error::OpError("storage smaller than shape requires".into()));
+    if axes.is_none() {
+        let mut sum = D::default();
+        if input.layout.is_contiguous() && input.layout.offset_bytes() == 0 {
+            let numel: usize = input_shape.iter().product();
+            for slot in input_data.iter().take(numel) {
+                sum = sum + unsafe { slot.assume_init() };
+            }
+        } else {
+            for byte_offset in input.layout.iter_offsets(D::DTYPE)? {
+                let idx = byte_offset / elem_size;
+                sum = sum + unsafe { input_data[idx].assume_init() };
+            }
         }
-        for slot in data.iter().take(numel) {
-            sum += unsafe { slot.assume_init() }.to_f32();
-        }
+        let mean = sum / D::from(count).unwrap();
+        out_data[0].write(mean);
     } else {
-        for idx_bytes in input.layout.iter_offsets(D::DTYPE)? {
-            debug_assert_eq!(idx_bytes % elem_size, 0);
-            let idx = idx_bytes / elem_size;
-            sum += unsafe { data[idx].assume_init() }.to_f32();
+        let canonical = canonical_axes(axes.unwrap(), input_shape.len())?;
+
+        let mut logical_idx = 0;
+        for byte_offset in input.layout.iter_offsets(D::DTYPE)? {
+            let idx = byte_offset / elem_size;
+            let value = unsafe { input_data[idx].assume_init() };
+
+            let input_indices = compute_multi_index_from_linear(logical_idx, input_shape);
+
+            let output_linear_idx =
+                compute_output_linear_index(&input_indices, &canonical, &output_shape, keepdims);
+
+            let current = unsafe { out_data[output_linear_idx].assume_init_ref() };
+            out_data[output_linear_idx].write(*current + value);
+
+            logical_idx += 1;
+        }
+
+        // Divide all accumulated sums by count to get means
+        let count_per_output = D::from(count).unwrap();
+        for slot in out_data.iter_mut().take(output_numel) {
+            let sum_val = unsafe { slot.assume_init() };
+            slot.write(sum_val / count_per_output);
         }
     }
 
-    let mean = sum / (numel as f32);
-
-    let mut out_storage = alloc_f32.allocate(1)?;
-    out_storage.try_as_uninit_slice_mut()?[0].write(mean);
-
-    let out_layout = Layout::contiguous(ConcreteShape::from_slice(&[1])?);
+    let out_layout = Layout::contiguous(ConcreteShape::from_slice(&output_shape)?);
 
     Ok(TensorParts {
         storage: out_storage,
@@ -62,28 +121,23 @@ where
 }
 
 impl MeanKernel for f32 {
-    fn mean_f32_kernel(
-        input: CpuTensorView<'_, Self>,
-        alloc_f32: &CpuAllocator<f32>,
-    ) -> Result<TensorParts<CpuStorage<f32>>> {
-        reduce_to_mean_f32(input, alloc_f32)
+    fn mean_kernel(
+        view: CpuTensorView<'_, Self>,
+        axes: Option<&[usize]>,
+        keepdims: bool,
+        allocator: &CpuAllocator<Self>,
+    ) -> Result<TensorParts<CpuStorage<Self>>> {
+        reduce_mean(view, axes, keepdims, allocator)
     }
 }
 
 impl MeanKernel for f64 {
-    fn mean_f32_kernel(
-        input: CpuTensorView<'_, Self>,
-        alloc_f32: &CpuAllocator<f32>,
-    ) -> Result<TensorParts<CpuStorage<f32>>> {
-        reduce_to_mean_f32(input, alloc_f32)
-    }
-}
-
-impl MeanKernel for i32 {
-    fn mean_f32_kernel(
-        input: CpuTensorView<'_, Self>,
-        alloc_f32: &CpuAllocator<f32>,
-    ) -> Result<TensorParts<CpuStorage<f32>>> {
-        reduce_to_mean_f32(input, alloc_f32)
+    fn mean_kernel(
+        view: CpuTensorView<'_, Self>,
+        axes: Option<&[usize]>,
+        keepdims: bool,
+        allocator: &CpuAllocator<Self>,
+    ) -> Result<TensorParts<CpuStorage<Self>>> {
+        reduce_mean(view, axes, keepdims, allocator)
     }
 }

--- a/crates/bolt-cpu/src/backend/ops/mod.rs
+++ b/crates/bolt-cpu/src/backend/ops/mod.rs
@@ -60,7 +60,6 @@ pub trait CpuScalar:
     + SubKernel
     + MatmulKernel
     + MulKernel
-    + MeanKernel
     + NegKernel
     + AbsKernel
     + ReluKernel
@@ -85,7 +84,6 @@ impl<T> CpuScalar for T where
         + SubKernel
         + MatmulKernel
         + MulKernel
-        + MeanKernel
         + NegKernel
         + AbsKernel
         + ReluKernel

--- a/crates/bolt-cpu/tests/reduction_ops_tests.rs
+++ b/crates/bolt-cpu/tests/reduction_ops_tests.rs
@@ -515,3 +515,118 @@ fn argmax_multi_axis_keepdims_f32() -> Result<()> {
     assert_eq!(result_vec[2], 1);
     Ok(())
 }
+
+// Mean reduction tests
+#[test]
+fn mean_all_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 2.0, 3.0, 4.0], &[2, 2])?;
+
+    let result = tensor.mean(None, false)?;
+    assert_eq!(result.shape(), &[]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 1);
+    assert!((result_vec[0] - 2.5).abs() < 1e-6);
+    Ok(())
+}
+
+#[test]
+fn mean_all_keepdims_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 2.0, 3.0, 4.0], &[2, 2])?;
+
+    let result = tensor.mean(None, true)?;
+    assert_eq!(result.shape(), &[1, 1]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 1);
+    assert!((result_vec[0] - 2.5).abs() < 1e-6);
+    Ok(())
+}
+
+#[test]
+fn mean_axis_0_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(
+        &backend,
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        &[3, 2],
+    )?;
+
+    let result = tensor.mean(Some(&[0]), false)?;
+    assert_eq!(result.shape(), &[2]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 2);
+    assert!((result_vec[0] - 3.0).abs() < 1e-6);  // (1+3+5)/3 = 3
+    assert!((result_vec[1] - 4.0).abs() < 1e-6);  // (2+4+6)/3 = 4
+    Ok(())
+}
+
+#[test]
+fn mean_axis_1_keepdims_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(
+        &backend,
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        &[3, 2],
+    )?;
+
+    let result = tensor.mean(Some(&[1]), true)?;
+    assert_eq!(result.shape(), &[3, 1]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 3);
+    assert!((result_vec[0] - 1.5).abs() < 1e-6);  // (1+2)/2 = 1.5
+    assert!((result_vec[1] - 3.5).abs() < 1e-6);  // (3+4)/2 = 3.5
+    assert!((result_vec[2] - 5.5).abs() < 1e-6);  // (5+6)/2 = 5.5
+    Ok(())
+}
+
+#[test]
+fn mean_multi_axis_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(
+        &backend,
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        &[2, 2, 2],
+    )?;
+
+    let result = tensor.mean(Some(&[0, 2]), false)?;
+    assert_eq!(result.shape(), &[2]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 2);
+    // Mean over axes 0 and 2 for a [2,2,2] tensor
+    // For position [0] in result: mean of [1,2,5,6] = 3.5
+    // For position [1] in result: mean of [3,4,7,8] = 5.5
+    assert!((result_vec[0] - 3.5).abs() < 1e-6);
+    assert!((result_vec[1] - 5.5).abs() < 1e-6);
+    Ok(())
+}
+
+#[test]
+fn mean_multi_axis_keepdims_f32() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(
+        &backend,
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        &[2, 2, 2],
+    )?;
+
+    let result = tensor.mean(Some(&[0, 2]), true)?;
+    assert_eq!(result.shape(), &[1, 2, 1]);
+    let result_vec = result.to_vec()?;
+    assert_eq!(result_vec.len(), 2);
+    assert!((result_vec[0] - 3.5).abs() < 1e-6);
+    assert!((result_vec[1] - 5.5).abs() < 1e-6);
+    Ok(())
+}
+
+#[test]
+fn mean_f64() -> Result<()> {
+    let backend = Arc::new(CpuBackend::new());
+    let tensor = Tensor::<CpuBackend, f64>::from_slice(&backend, &[1.0, 2.0, 3.0, 4.0], &[2, 2])?;
+
+    let result = tensor.mean(None, false)?;
+    assert_eq!(result.shape(), &[]);
+    let result_vec = result.to_vec()?;
+    assert!((result_vec[0] - 2.5).abs() < 1e-10);
+    Ok(())
+}

--- a/crates/bolt-cpu/tests/tensor_ops.rs
+++ b/crates/bolt-cpu/tests/tensor_ops.rs
@@ -53,10 +53,10 @@ fn non_contiguous_view_ops() -> Result<()> {
 }
 
 #[test]
-fn mean_returns_f32() -> Result<()> {
+fn mean_full_reduction() -> Result<()> {
     let backend = Arc::new(CpuBackend::new());
-    let tensor = Tensor::<CpuBackend, i32>::from_slice(&backend, &[1, 3, 5, 7], &[2, 2])?;
-    let mean = tensor.mean_f32()?.to_vec()?; // mean_f32 should return tensor of dtype f32
+    let tensor = Tensor::<CpuBackend, f32>::from_slice(&backend, &[1.0, 3.0, 5.0, 7.0], &[2, 2])?;
+    let mean = tensor.mean(None, false)?.to_vec()?;
     assert_eq!(mean, vec![4.0]);
     Ok(())
 }
@@ -65,7 +65,7 @@ fn mean_returns_f32() -> Result<()> {
 fn mean_handles_f64_inputs() -> Result<()> {
     let backend = Arc::new(CpuBackend::new());
     let tensor = Tensor::<CpuBackend, f64>::from_slice(&backend, &[1.0, 3.0, 5.0, 7.0], &[2, 2])?;
-    let mean = tensor.mean_f32()?.to_vec()?;
+    let mean = tensor.mean(None, false)?.to_vec()?;
     assert_eq!(mean, vec![4.0]);
     Ok(())
 }

--- a/crates/bolt-examples/src/bin/gradient_descent.rs
+++ b/crates/bolt-examples/src/bin/gradient_descent.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let y_pred = x.matmul(&w)?;
         let diff = y_pred.sub(&y)?;
-        let loss = diff.mul(&diff)?.mean(None)?;
+        let loss = diff.mul(&diff)?.mean(None, false)?;
 
         let grads = graph.backward(&loss)?;
         let dw = grads.wrt(&w).unwrap();

--- a/crates/bolt-examples/src/bin/workload_profiling.rs
+++ b/crates/bolt-examples/src/bin/workload_profiling.rs
@@ -67,7 +67,7 @@ fn run_mean_reduction(backend: &Arc<ProfiledBackend<CpuBackend>>) -> AnyResult<(
     let len = shape.iter().product();
     let data = make_data(len, 0.0001);
     let tensor = Tensor::from_slice(backend, &data, &shape)?;
-    let _ = tensor.mean_f32()?;
+    let _ = tensor.mean(None, false)?;
     Ok(())
 }
 

--- a/crates/bolt-profiler/src/backend.rs
+++ b/crates/bolt-profiler/src/backend.rs
@@ -1,5 +1,5 @@
 use bolt_core::backend::{AddOp, Backend, CopyOp, FillOp, MatmulOp, MeanOp, SubOp, TensorParts};
-use bolt_core::dtype::NativeType;
+use bolt_core::dtype::{FloatType, NativeType};
 use bolt_core::error::Result;
 use bolt_core::layout::Layout;
 
@@ -209,20 +209,20 @@ impl<D: NativeType, B: MatmulOp<D> + Backend<D>> MatmulOp<D> for ProfiledBackend
     }
 }
 
-impl<D: NativeType, B: MeanOp<D> + Backend<D>> MeanOp<D> for ProfiledBackend<B> {
-    type F32Storage = B::F32Storage;
-
-    fn mean_f32(
+impl<D: FloatType, B: MeanOp<D> + Backend<D>> MeanOp<D> for ProfiledBackend<B> {
+    fn mean(
         &self,
-        storage: &<Self as Backend<D>>::Storage,
         layout: &Layout,
-    ) -> Result<TensorParts<Self::F32Storage>> {
+        storage: &Self::Storage,
+        axes: Option<&[usize]>,
+        keepdims: bool,
+    ) -> Result<TensorParts<Self::Storage>> {
         profile_op(
             self,
-            "mean_f32",
+            "mean",
             OpCategory::Compute,
             vec![shapes_from_layout(layout)],
-            |inner| inner.mean_f32(storage, layout),
+            |inner| inner.mean(layout, storage, axes, keepdims),
         )
     }
 }


### PR DESCRIPTION
Closes #55 

Standardize reduction operations to accept axes and keepdims parameters. Refactor MeanOp to compute mean directly rather than delegating to sum, and update the trait to use FloatType constraint instead of NativeType. Add .DS_Store to gitignore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Sum and mean operations now require an additional `keepdims` boolean parameter.
  * `mean_f32()` method removed; use the generic `mean(axes, keepdims)` method instead.

* **New Features**
  * Mean operation now supports flexible axis reduction with keepdims support across all floating-point tensor types.

* **Chores**
  * Updated .gitignore to exclude system files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->